### PR TITLE
Deprecate role param.

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -35,7 +35,6 @@ func (u *InputUnifi) newDynamicCntrlr(url string) (bool, *Controller) {
 
 	ccopy := u.Default // copy defaults into new controller
 	u.dynamic[url] = &ccopy
-	u.dynamic[url].Role = url
 	u.dynamic[url].URL = url
 
 	return true, u.dynamic[url]
@@ -67,7 +66,7 @@ func (u *InputUnifi) collectController(c *Controller) (*poller.Metrics, error) {
 		u.Logf("Re-authenticating to UniFi Controller: %s", c.URL)
 
 		if err := u.getUnifi(c); err != nil {
-			return nil, errors.Wrapf(err, "re-authenticating to %s", c.Role)
+			return nil, errors.Wrapf(err, "re-authenticating to %s", c.URL)
 		}
 	}
 
@@ -76,7 +75,7 @@ func (u *InputUnifi) collectController(c *Controller) (*poller.Metrics, error) {
 		u.Logf("Re-authenticating to UniFi Controller: %s", c.URL)
 
 		if err := u.getUnifi(c); err != nil {
-			return metrics, errors.Wrapf(err, "re-authenticating to %s", c.Role)
+			return metrics, errors.Wrapf(err, "re-authenticating to %s", c.URL)
 		}
 	}
 

--- a/input.go
+++ b/input.go
@@ -38,7 +38,6 @@ type Controller struct {
 	SaveDPI   *bool        `json:"save_dpi" toml:"save_dpi" xml:"save_dpi" yaml:"save_dpi"`
 	HashPII   *bool        `json:"hash_pii" toml:"hash_pii" xml:"hash_pii" yaml:"hash_pii"`
 	SaveSites *bool        `json:"save_sites" toml:"save_sites" xml:"save_sites" yaml:"save_sites"`
-	Role      string       `json:"role" toml:"role" xml:"role,attr" yaml:"role"`
 	User      string       `json:"user" toml:"user" xml:"user" yaml:"user"`
 	Pass      string       `json:"pass" toml:"pass" xml:"pass" yaml:"pass"`
 	URL       string       `json:"url" toml:"url" xml:"url" yaml:"url"`
@@ -117,7 +116,7 @@ func (u *InputUnifi) checkSites(c *Controller) error {
 		msg = append(msg, site.Name+" ("+site.Desc+")")
 	}
 
-	u.Logf("Found %d site(s) on controller %s: %v", len(msg), c.Role, strings.Join(msg, ", "))
+	u.Logf("Found %d site(s) on controller %s: %v", len(msg), c.URL, strings.Join(msg, ", "))
 
 	if StringInSlice("all", c.Sites) {
 		c.Sites = []string{"all"}
@@ -134,7 +133,7 @@ FIRST:
 				continue FIRST
 			}
 		}
-		u.LogErrorf("Configured site not found on controller %s: %v", c.Role, s)
+		u.LogErrorf("Configured site not found on controller %s: %v", c.URL, s)
 	}
 
 	if c.Sites = keep; len(keep) == 0 {
@@ -201,10 +200,6 @@ func (u *InputUnifi) setDefaults(c *Controller) {
 		c.URL = defaultURL
 	}
 
-	if c.Role == "" {
-		c.Role = c.URL
-	}
-
 	if strings.HasPrefix(c.Pass, "file://") {
 		c.Pass = u.getPassFromFile(strings.TrimPrefix(c.Pass, "file://"))
 	}
@@ -248,12 +243,6 @@ func (u *InputUnifi) setControllerDefaults(c *Controller) *Controller {
 
 	if c.URL == "" {
 		c.URL = u.Default.URL
-	}
-
-	if c.Role == "" && u.Default.Role != u.Default.URL {
-		c.Role = u.Default.Role
-	} else if c.Role == "" {
-		c.Role = c.URL
 	}
 
 	if strings.HasPrefix(c.Pass, "file://") {

--- a/interface.go
+++ b/interface.go
@@ -81,13 +81,13 @@ func (u *InputUnifi) Metrics() (*poller.Metrics, bool, error) {
 
 // MetricsFrom grabs all the measurements from a UniFi controller and returns them.
 func (u *InputUnifi) MetricsFrom(filter *poller.Filter) (*poller.Metrics, bool, error) {
-	if u.Disable || filter == nil || filter.Path == "" {
+	if u.Disable {
 		return nil, false, nil
 	}
 
 	// Check if the request is for an existing, configured controller.
 	for _, c := range u.Controllers {
-		if !strings.EqualFold(c.URL, filter.Path) {
+		if filter != nil && !strings.EqualFold(c.URL, filter.Path) {
 			continue
 		}
 
@@ -96,7 +96,7 @@ func (u *InputUnifi) MetricsFrom(filter *poller.Filter) (*poller.Metrics, bool, 
 		return m, err == nil && m != nil, err
 	}
 
-	if !u.Dynamic {
+	if !u.Dynamic || filter == nil {
 		return nil, false, errDynamicLookupsDisabled
 	}
 

--- a/interface.go
+++ b/interface.go
@@ -45,7 +45,7 @@ func (u *InputUnifi) Initialize(l poller.Logger) error {
 		switch err := u.getUnifi(u.setControllerDefaults(c)); err {
 		case nil:
 			if err := u.checkSites(c); err != nil {
-				u.LogErrorf("checking sites on %s: %v", c.Role, err)
+				u.LogErrorf("checking sites on %s: %v", c.URL, err)
 			}
 
 			u.Logf("Configured UniFi Controller %d:", i+1)
@@ -67,7 +67,6 @@ func (u *InputUnifi) logController(c *Controller) {
 	}
 
 	u.Logf("   => Username: %s (has password: %v)", c.User, c.Pass != "")
-	u.Logf("   => Role: %s", c.Role)
 	u.Logf("   => Hash PII: %v", *c.HashPII)
 	u.Logf("   => Verify SSL: %v", *c.VerifySSL)
 	u.Logf("   => Save DPI: %v", *c.SaveDPI)
@@ -82,49 +81,29 @@ func (u *InputUnifi) Metrics() (*poller.Metrics, bool, error) {
 
 // MetricsFrom grabs all the measurements from a UniFi controller and returns them.
 func (u *InputUnifi) MetricsFrom(filter *poller.Filter) (*poller.Metrics, bool, error) {
-	if u.Disable {
+	if u.Disable || filter == nil || filter.Path == "" {
 		return nil, false, nil
-	}
-
-	errs := []string{}
-	metrics := &poller.Metrics{}
-	ok := false
-
-	if filter != nil && filter.Path != "" {
-		if !u.Dynamic {
-			return metrics, false, errDynamicLookupsDisabled
-		}
-
-		// Attempt a dynamic metrics fetch from an unconfigured controller.
-		m, err := u.dynamicController(filter.Path)
-
-		return m, err == nil && m != nil, err
 	}
 
 	// Check if the request is for an existing, configured controller.
 	for _, c := range u.Controllers {
-		if filter != nil && !strings.EqualFold(c.Role, filter.Role) {
+		if !strings.EqualFold(c.URL, filter.Path) {
 			continue
 		}
 
 		m, err := u.collectController(c)
-		if err != nil {
-			errs = append(errs, err.Error())
-		}
 
-		if m == nil {
-			continue
-		}
-
-		ok = true
-		metrics = poller.AppendMetrics(metrics, m)
+		return m, err == nil && m != nil, err
 	}
 
-	if len(errs) > 0 {
-		return metrics, ok, fmt.Errorf(strings.Join(errs, ", ")) // nolint: goerr113
+	if !u.Dynamic {
+		return nil, false, errDynamicLookupsDisabled
 	}
 
-	return metrics, ok, nil
+	// Attempt a dynamic metrics fetch from an unconfigured controller.
+	m, err := u.dynamicController(filter.Path)
+
+	return m, err == nil && m != nil, err
 }
 
 // RawMetrics returns API output from the first configured unifi controller.
@@ -138,7 +117,7 @@ func (u *InputUnifi) RawMetrics(filter *poller.Filter) ([]byte, error) {
 		u.Logf("Re-authenticating to UniFi Controller: %s", c.URL)
 
 		if err := u.getUnifi(c); err != nil {
-			return nil, errors.Wrapf(err, "re-authenticating to %s", c.Role)
+			return nil, errors.Wrapf(err, "re-authenticating to %s", c.URL)
 		}
 	}
 


### PR DESCRIPTION
- No longer using the role param. 
- The only filter option used now is `path`. 
- `MetricsFrom` Logic: 
  - First check for configured controller, 
     -  if `filter` empty, then collect all configured controllers
  - then check for dynamic controller, 
  - then create dynamic controller.

Requires https://github.com/unifi-poller/promunifi/pull/3